### PR TITLE
Increased docker pull timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add minio-availability health check #57
 
+### Changed
+
+- Increased the [docker pull timeout](https://www.nomadproject.io/docs/drivers/docker#image_pull_timeout) for the hive-image #52
+
 ## [0.3.0]
 
 ### Added

--- a/conf/nomad/hive.hcl
+++ b/conf/nomad/hive.hcl
@@ -8,8 +8,8 @@ job "${service_name}" {
     max_parallel      = 1
     health_check      = "checks"
     min_healthy_time  = "10s"
-    healthy_deadline  = "12m"
-    progress_deadline = "15m"
+    healthy_deadline  = "20m"
+    progress_deadline = "25m"
 %{ if use_canary }
     canary            = 1
     auto_promote      = true
@@ -124,6 +124,7 @@ job "${service_name}" {
 %{ else }
       config {
         image = "${image}"
+        image_pull_timeout = "20m"
 %{ endif }
         command = "hivemetastore"
       }


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #52 

## What was added/changed/fixed?
Extended the docker pull timeout for the hive-image in the HCL-file. The image is very big, and had problems downloading before the timeout when on a macbook via VPN

## Related issue(s)? [Optional]

## Others [Optional]

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone